### PR TITLE
CON-523: Revert hiding of final modifier

### DIFF
--- a/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
@@ -28,9 +28,7 @@ class JavaSignatureProvider internal constructor(ctcc: CommentsToContentConverte
     private val contentBuilder = PageContentBuilder(ctcc, this, logger)
 
     private val ignoredVisibilities = setOf(JavaVisibility.Default)
-
-    // R3: Hide 'Final' modifier from generated docs.
-    // R3: Remove hiding 'Final' modifier.
+    
     private val ignoredModifiers =
         setOf(KotlinModifier.Open, JavaModifier.Empty, KotlinModifier.Empty, KotlinModifier.Sealed)
 

--- a/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
+++ b/plugins/kotlin-as-java/src/main/kotlin/signatures/JavaSignatureProvider.kt
@@ -30,8 +30,9 @@ class JavaSignatureProvider internal constructor(ctcc: CommentsToContentConverte
     private val ignoredVisibilities = setOf(JavaVisibility.Default)
 
     // R3: Hide 'Final' modifier from generated docs.
+    // R3: Remove hiding 'Final' modifier.
     private val ignoredModifiers =
-        setOf(KotlinModifier.Open, JavaModifier.Empty, KotlinModifier.Empty, KotlinModifier.Sealed, KotlinModifier.Final, JavaModifier.Final)
+        setOf(KotlinModifier.Open, JavaModifier.Empty, KotlinModifier.Empty, KotlinModifier.Sealed)
 
     override fun signature(documentable: Documentable): List<ContentNode> = when (documentable) {
         is DFunction -> signature(documentable)


### PR DESCRIPTION
Remove 'KotlinModifier.Final' and 'JavaModifier.Final' from `ignoredModifiers` to display 'Final', wherever applicable, in the API docs.